### PR TITLE
[python/rosbag] plot transformation between odom and base_footprint

### DIFF
--- a/python/rosbag/odom-body.py
+++ b/python/rosbag/odom-body.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+import matplotlib.pyplot
+import argparse, rosbag, tf, math
+
+parser = argparse.ArgumentParser(description='check transformation between odom and base_footprint')
+parser.add_argument('-f', help='target rosbag file', type=str, required=True)
+args = parser.parse_args()
+
+x_list = []
+y_list = []
+yaw_list = []
+tm_list = []
+
+for topic, msg, t in rosbag.Bag(args.f):
+    if topic == "/tf":
+        for trans in msg.transforms:
+            if trans.child_frame_id == "base_footprint" and trans.header.frame_id == "odom":
+                rot = trans.transform.rotation
+                rpy = tf.transformations.euler_from_quaternion([rot.x, rot.y, rot.z, rot.w])
+                x_list.append(trans.transform.translation.x)
+                y_list.append(trans.transform.translation.y)
+                yaw_list.append(rpy[2])
+                tm_list.append(t.to_time())
+
+# plot yaw direction once every 30 times
+for x, y, yaw, t in zip(x_list, y_list, yaw_list, tm_list)[::30]:
+    matplotlib.pyplot.quiver(x, y, 0.05 * math.cos(yaw), 0.05 * math.sin(yaw), angles='xy', scale=2, headwidth=1)
+# plot the start and end point
+start = [x_list[0], y_list[0]]
+end = [x_list[-1], y_list[-1]]
+distance = math.sqrt(math.pow(end[0] - start[0], 2) + math.pow(end[1] - start[1], 2))
+matplotlib.pyplot.plot(start[0], start[1], 'ro')
+matplotlib.pyplot.plot(end[0], end[1], 'go')
+title = "start : [" + ("%.3f" % start[0]) + ", " + ("%.3f" % start[1]) + "], end : [" + ("%.3f" % end[0]) + ", " + ("%.3f" % end[1]) + "], distance : " + ("%.3f" % distance)
+matplotlib.pyplot.title(title)
+# plot all the points
+matplotlib.pyplot.plot(x_list, y_list)
+matplotlib.pyplot.minorticks_on()
+matplotlib.pyplot.grid(True)
+matplotlib.pyplot.axes().set_aspect('equal')
+matplotlib.pyplot.show()


### PR DESCRIPTION
![aaa](https://cloud.githubusercontent.com/assets/4509039/11897998/b70ee518-a5d7-11e5-9166-414ac463a706.png)

``` bash
rtmlaunch hrpsys_ros_bridge samplerobot.launch RUN_RVIZ:=false USE_UNSTABLE_RTC:=true
```

でシミュレーションを上げて，

``` lisp
(progn
  (load "package://hrpsys_ros_bridge/euslisp/samplerobot-interface.l")
  (setq *robot* (samplerobot-init))
  (send *ri* :angle-vector (send *robot* :reset-pose) 2000)
  (send *ri* :wait-interpolation)
  (send *ri* :set-auto-balancer-param :leg-names (list :rleg :lleg))
  (send *ri* :set-gait-generator-param :zmp-weight-map (list 1 1 1 1) :default-step-height 0.065)
  (send *ri* :start-auto-balancer :limbs (list :rleg :lleg :rarm :larm))
  )
```

で準備してから，`rosbag record /tf -o hoge`でbagを取りつつ，`(send *ri* :go-pos 1 1 45)`のときのプロット．
