### PR TITLE
[python/rosbag/topic-odom.py] check odom of topic

### DIFF
--- a/python/rosbag/topic-odom.py
+++ b/python/rosbag/topic-odom.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+import matplotlib.pyplot
+import argparse, rosbag, tf, math
+
+parser = argparse.ArgumentParser(description='check transformation between odom and body link')
+parser.add_argument('-f', help='target rosbag file', type=str, required=True)
+args = parser.parse_args()
+
+x_list = []
+y_list = []
+yaw_list = []
+tm_list = []
+
+for topic, msg, t in rosbag.Bag(args.f):
+    if topic == "/odom":
+        rot = msg.pose.pose.orientation
+        rpy = tf.transformations.euler_from_quaternion([rot.x, rot.y, rot.z, rot.w])
+        x_list.append(msg.pose.pose.position.x)
+        y_list.append(msg.pose.pose.position.y)
+        yaw_list.append(rpy[2])
+        tm_list.append(t.to_time())
+
+# plot yaw direction once every 30 times
+for x, y, yaw, t in zip(x_list, y_list, yaw_list, tm_list)[::30]:
+    matplotlib.pyplot.quiver(x, y, 0.05 * math.cos(yaw), 0.05 * math.sin(yaw), angles='xy', scale=2, headwidth=1)
+# plot the start and end point
+start = [x_list[0], y_list[0]]
+end = [x_list[-1], y_list[-1]]
+distance = math.sqrt(math.pow(end[0] - start[0], 2) + math.pow(end[1] - start[1], 2))
+matplotlib.pyplot.plot(start[0], start[1], 'ro')
+matplotlib.pyplot.plot(end[0], end[1], 'go')
+title = "start : [" + ("%.3f" % start[0]) + ", " + ("%.3f" % start[1]) + "], end : [" + ("%.3f" % end[0]) + ", " + ("%.3f" % end[1]) + "], distance : " + ("%.3f" % distance)
+matplotlib.pyplot.title(title)
+# plot all the points
+matplotlib.pyplot.plot(x_list, y_list)
+matplotlib.pyplot.minorticks_on()
+matplotlib.pyplot.grid(True)
+matplotlib.pyplot.axes().set_aspect('equal')
+matplotlib.pyplot.show()


### PR DESCRIPTION
https://github.com/eisoku9618/kuroiwa_demos/pull/23 はtfのodomを見ていたけど，tfのodomはrobot_pose_ekfが出していて，そのもととなっているのが，HrpsysSeqStateの正しいか不明の速度入力なので，ダメだった．

一方で，topicのodomのposeはabcの出力しか見ていないので，欲しかったのはこれ．

``` lisp
(defun my-test ()
  (send *ri* :go-pos 1 0 0)
  (biped->quadruped)
  (send *ri* :set-foot-steps (cc-converter (get-xy-footstep 1000 0 :forward-offset-length 150 :outside-offset-length 100 :type :crawl)))
  (send *ri* :set-foot-steps (cc-converter (get-xy-footstep 0 200 :forward-offset-length 150 :outside-offset-length 100 :type :crawl)))
  (quadruped->biped)
  (send *ri* :go-pos 0 0.5 0)
  )
```

をしたときの，crawl

![crawl](https://cloud.githubusercontent.com/assets/4509039/11903548/69ab82e2-a5fd-11e5-9198-a9eaea7831d0.png)

同じ距離で，trot

![trot](https://cloud.githubusercontent.com/assets/4509039/11903549/69cbc5de-a5fd-11e5-9238-462bb963af5a.png)
